### PR TITLE
feat: Add `once` options to detect intersecting once

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ const Component: React.FC = () => {
 };
 ```
 
+### Lazy Image
+
+This is an example of an Image component that delays loading.
+
+```typescript
+import * as React from 'react';
+import { useIntersection } from 'use-intersection';
+
+const Component: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = (props) => {
+  const target = React.useRef<HTMLDivElement>(null);
+  const intersected = useIntersection(target, {
+    rootMargin: '250px',
+    once: true,
+  });
+
+  return intersected ? <img {...props} /> : <span />;
+};
+```
+
 ## Browser support
 
 Supports modern web browser.
@@ -88,10 +107,12 @@ The following resources will help you.
 
 ---
 
+### `useIntersection`
+
 `useIntersection` is returns a flag whether the target intersects.
 
 ```typescript
-useIntersection(
+const useIntersection = (
   ref: React.RefObject<Element>,
   options: IntersectionOptions = {},
   callback?: IntersectionChangeHandler,
@@ -101,18 +122,19 @@ useIntersection(
 ### `options: IntersectionOptions`
 
 ```typescript
-{
+type IntersectionOptions = {
   root?: React.RefObject<Element>;
   rootMargin?: string;
   threshold?: number | number[];
+  once?: boolean;
   defaultIntersecting?: boolean;
-}
+};
 ```
 
 ### `callback: IntersectionChangeHandler`
 
 ```typescript
-(entry: IntersectionObserverEntry) => void
+type IntersectionChangeHandler = (entry: IntersectionObserverEntry) => void;
 ```
 
 ## CHANGELOG

--- a/src/__stories__/Demo.stories.tsx
+++ b/src/__stories__/Demo.stories.tsx
@@ -95,8 +95,32 @@ const WithRoot: React.FC = () => {
   );
 };
 
+const WithOnce: React.FC = () => {
+  const target = React.useRef<HTMLDivElement>(null);
+  const intersected = useIntersection(
+    target,
+    {
+      once: true,
+    },
+    action('onChange'),
+  );
+
+  const empty = <Empty intersecting={intersected} />;
+
+  return (
+    <>
+      {empty}
+      <div ref={target}>
+        <Text intersecting={intersected} />
+      </div>
+      {empty}
+    </>
+  );
+};
+
 storiesOf('useIntersection', module)
   .addDecorator(withKnobs)
   .add('overview', () => <Overview />)
   .add('with threshold (0.8)', () => <WithThreshold />)
-  .add('with root element and rootMargin (100px)', () => <WithRoot />);
+  .add('with root element and rootMargin (100px)', () => <WithRoot />)
+  .add('with once', () => <WithOnce />);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type IntersectionOptions = {
   root?: React.RefObject<Element>;
   rootMargin?: string;
   threshold?: number | number[];
+  once?: boolean;
   defaultIntersecting?: boolean;
 };
 
@@ -15,7 +16,7 @@ export const useIntersection = (
   options: IntersectionOptions = {},
   callback?: IntersectionChangeHandler,
 ) => {
-  const { defaultIntersecting, ...opts } = options;
+  const { defaultIntersecting, once, ...opts } = options;
   const optsRef = useRef(opts);
   const [intersecting, setIntersecting] = useState(defaultIntersecting === true);
 
@@ -33,8 +34,13 @@ export const useIntersection = (
     const observer = new IntersectionObserver(
       ([entry]) => {
         setIntersecting(entry.isIntersecting);
+
         if (callback != null) {
           callback(entry);
+        }
+
+        if (once && entry.isIntersecting && ref.current != null) {
+          observer.unobserve(ref.current);
         }
       },
       {
@@ -46,7 +52,7 @@ export const useIntersection = (
     observer.observe(ref.current);
 
     return () => {
-      if (ref.current != null) {
+      if (!once && ref.current != null) {
         observer.unobserve(ref.current);
       }
     };


### PR DESCRIPTION
<!-- Thank you for your contribution to use-intersection! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

We often want to detect that we intersecting only once. For example, when implementing lazy loading of images.

This PR implemented the `once` option to achieve its expected behavior.

## How this PR fixes the problem?

None.

## What should your reviewer look out for in this PR?

None.

## Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

## Additional Comments (if any)

:dog:

## Which issue(s) does this PR fix?

<!--
fixes #
fixes #
-->
