### PR TITLE
feat: support to pass Element as target param

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/storybook__addon-knobs": "5.0.3",
     "@types/storybook__react": "4.0.2",
     "@typescript-eslint/eslint-plugin": "1.5.0",
+    "babel-loader": "^8.0.6",
     "eslint": "5.16.0",
     "eslint-config-prettier": "6.0.0",
     "eslint-plugin-prettier": "3.1.0",

--- a/src/__stories__/Demo.stories.tsx
+++ b/src/__stories__/Demo.stories.tsx
@@ -118,9 +118,30 @@ const WithOnce: React.FC = () => {
   );
 };
 
+const WithElement: React.FC = () => {
+  const [target, setTarget] = React.useState<Element | null>(null);
+  const intersected = useIntersection(target, {}, action('onChange'));
+
+  React.useEffect(() => {
+    setTarget(document.getElementById('target'));
+  }, []);
+
+  const empty = <Empty intersecting={intersected} />;
+
+  return (
+    <>
+      {empty}
+      <p id="target">target</p>
+      <Text intersecting={intersected} />
+      {empty}
+    </>
+  );
+};
+
 storiesOf('useIntersection', module)
   .addDecorator(withKnobs)
   .add('overview', () => <Overview />)
   .add('with threshold (0.8)', () => <WithThreshold />)
   .add('with root element and rootMargin (100px)', () => <WithRoot />)
-  .add('with once', () => <WithOnce />);
+  .add('with once', () => <WithOnce />)
+  .add('with element', () => <WithElement />);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2999,6 +2999,16 @@ babel-jest@^24.9.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
+babel-loader@^8.0.6:
+  version "8.0.6"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
+  integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
+  dependencies:
+    find-cache-dir "^2.0.0"
+    loader-utils "^1.0.2"
+    mkdirp "^0.5.1"
+    pify "^4.0.1"
+
 babel-plugin-add-react-displayname@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"


### PR DESCRIPTION
<!-- Thank you for your contribution to use-intersection! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

This PR contains following changes:
- allow `Element` object as target param to handle native elements

## How this PR fixes the problem?

- allow `Element` type as first param of `useIntersection`
- add `target` to dependencies of `useEffect` to follow `target`'s changes
- add `intersectedRef` to handle `once` option correctly

## What should your reviewer look out for in this PR?

- if this PR contains any breaking changes

## Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

## Additional Comments (if any)

I also added missing `babel-loader` package to `devDependencies` .

## Which issue(s) does this PR fix?

<!--
fixes #
fixes #
-->
