### PR TITLE
fix: use the last entry in intersection callback function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,8 @@ export const useIntersection = (
     }
 
     const observer = new IntersectionObserver(
-      ([entry]) => {
+      (entries) => {
+        const entry = entries[entries.length - 1];
         setIntersecting(entry.isIntersecting);
 
         if (callback != null) {


### PR DESCRIPTION
<!-- Thank you for your contribution to use-intersection! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

This PR changes to use the last element of entries in intersection callback function.

IntersectionObserver queues intersected entries until next execution of notification step.
In situations where the observed DOM intersects frequently, callback function may be called with an array contains multiple entries.
With previous implementation, this causes inconsistency of intersecting state.

## How this PR fixes the problem?

By using the last element of entries, useIntersection can handle latest intersecting state.

## Reference
[Algorithms, Intersection Observer Editor’s Draft, 13 April 2020](https://w3c.github.io/IntersectionObserver/#algorithms)
