### PR TITLE
(chore)correct the missing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ const Component: React.FC = () => {
   });
 
   return (
-    <div style={{ overflow: 'hidden auto', height: 300 }}>
+    <div ref={root} style={{ overflow: 'hidden auto', height: 300 }}>
       {/* ... */}
       <div ref={target}>{intersecting ? 'visible' : 'invisible'}</div>
       {/* ... */}


### PR DESCRIPTION
## What does this do / why do we need it?

As ref `root` is not attached to any jsx item, it'll always be null in the example in README.
