### PR TITLE
docs: remove polyfill io recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ $ yarn add intersection-observer
 ### CDN
 
 ```html
-<script src="https://polyfill.io/v3/polyfill.min.js?features=IntersectionObserverEntry%2CIntersectionObserver"></script>
+<script src="https://polyfill-fastly.io/v3/polyfill.min.js?features=IntersectionObserverEntry%2CIntersectionObserver"></script>
 ```
 
-> https://polyfill.io/v3/
+> https://polyfill-fastly.io/v3/
 
 ## API
 


### PR DESCRIPTION
<!-- Thank you for your contribution to use-intersection! Please replace {Please write here} with your description -->

## What does this do / why do we need it?

Due to the recent supply chain attack, updated the README.md.

## How this PR fixes the problem?

Replaced to fastly's polyfill service.
